### PR TITLE
Deploy Supabase to Production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: streamlit run src/dashboard.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,8 @@
+[phases.setup]
+nixPkgs = ["python39"]
+
+[phases.install]
+cmds = ["pip install -r requirements.txt"]
+
+[start]
+cmd = "streamlit run src/dashboard.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true"


### PR DESCRIPTION
Fix Railway deployment issue where the app wasn't starting correctly. Railway needs explicit configuration files to know how to start the Streamlit dashboard application.

Changes:
- Add Procfile with Streamlit start command
- Add nixpacks.toml with build and start configuration
- Both files configure the app to run on Railway's $PORT variable