### PR TITLE
Fix pip command not found in Docker build

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -2,7 +2,7 @@
 nixPkgs = ["python311"]
 
 [phases.install]
-cmds = ["pip install -r requirements.txt"]
+cmds = ["python -m pip install -r requirements.txt"]
 
 [start]
 cmd = "streamlit run src/dashboard.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true"


### PR DESCRIPTION
Changed pip install command to use 'python -m pip' instead of 'pip' directly. This ensures pip is found through Python's module system regardless of PATH configuration in the Docker build environment.

Fixes the build failures in both cbf-dashboard and cbf-scraper-daily services where pip was not found during the install phase.