### PR TITLE
Fix ModuleNotFoundError by setting PYTHONPATH and creating src package

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -5,4 +5,4 @@ nixPkgs = ["python311"]
 cmds = ["python -m pip install -r requirements.txt"]
 
 [start]
-cmd = "streamlit run src/dashboard.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true"
+cmd = "PYTHONPATH=/app:$PYTHONPATH streamlit run src/dashboard.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true"

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "nixpacksConfigPath": "nixpacks.toml"
   },
   "deploy": {
-    "startCommand": "streamlit run src/dashboard.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true",
+    "startCommand": "PYTHONPATH=/app:$PYTHONPATH streamlit run src/dashboard.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true",
     "healthcheckPath": "/_stcore/health",
     "healthcheckTimeout": 100,
     "restartPolicyType": "ON_FAILURE",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+"""
+CBF Robot - Football Match Analysis System
+"""
+
+__version__ = "1.0.0"


### PR DESCRIPTION
- Created src/__init__.py to make src a proper Python package
- Updated railway.json to set PYTHONPATH=/app in startCommand
- Updated nixpacks.toml to set PYTHONPATH=/app in start command

This resolves the "ModuleNotFoundError: No module named 'src'" error that occurred when importing modules like "from src.database import ..."