### PR TITLE
Fix pip module not found in Docker build

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -2,7 +2,11 @@
 nixPkgs = ["python311"]
 
 [phases.install]
-cmds = ["python -m pip install -r requirements.txt"]
+cmds = [
+    "python -m ensurepip --upgrade",
+    "python -m pip install --upgrade pip",
+    "python -m pip install -r requirements.txt"
+]
 
 [start]
 cmd = "PYTHONPATH=/app:$PYTHONPATH streamlit run src/dashboard.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true"


### PR DESCRIPTION
The Python311 package from Nix doesn't include pip by default. This commit adds a step to bootstrap pip using ensurepip before attempting to install requirements, which ensures pip is available in the build environment.

Changes:
- Use 'python -m ensurepip --upgrade' to bootstrap pip
- Upgrade pip itself before installing requirements
- Then proceed with normal requirements installation

This resolves the "No module named pip" error in Railway's Nixpacks build process.