### PR TITLE
Fix Python pip installation error on Railway

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,9 +1,9 @@
 [phases.setup]
-nixPkgs = ["python311"]
+nixPkgs = ["python311", "python311Packages.pip"]
 
 [phases.install]
 cmds = [
-    "python -m ensurepip --upgrade",
-    "python -m pip install --upgrade pip",
-    "python -m pip install -r requirements.txt"
+    "python -m venv /opt/venv",
+    "/opt/venv/bin/pip install --upgrade pip",
+    "/opt/venv/bin/pip install -r requirements.txt"
 ]

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "nixpacksConfigPath": "nixpacks.toml"
   },
   "deploy": {
-    "startCommand": "PYTHONPATH=/app:$PYTHONPATH streamlit run src/dashboard.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true",
+    "startCommand": "PYTHONPATH=/app:$PYTHONPATH /opt/venv/bin/streamlit run src/dashboard.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true",
     "healthcheckPath": "/_stcore/health",
     "healthcheckTimeout": 100,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
The previous configuration tried to use ensurepip which fails with Nix's immutable Python environment. This commit fixes the issue by:

- Creating a Python virtual environment at /opt/venv
- Installing packages into the virtual environment instead of the Nix store
- Adding python311Packages.pip to nixPkgs for pip availability
- Updating Railway start command to use the virtual environment's streamlit

This approach works with Nix's externally-managed Python environment while still allowing package installation.